### PR TITLE
[FEAT] exit if password in SMNRP_USERS is not set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -316,10 +316,16 @@ EOF
     rm -f ${auth_config}
     readarray -d , -t users < <(printf '%s' "${vhost_users[i]}")
     for user in ${users[@]}
-    do
+    do    
       parts=($(echo "$user" | tr ':' '\n'))
       _user=${parts[0]}
       _pass=${parts[1]}
+      if [ -z "$_pass" ]; then
+        echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+        echo "No password set for user $_user!"
+        echo "Set a password and restart the container"
+        exit 1
+      fi
       echo "### User for ${domain}: ${_user}"
       htpasswd -bc "${auth_config}" "${_user}" "${_pass}"
     done


### PR DESCRIPTION
Currently the service will start if an SMNRP_USER is given without a password. This might happen, if set via env var and the env var is not set due to a config error.

`SMNRP_USERS=admin:${PW}`

As a result the proxied services would be reachable with the username and "" as password.

I have added a check that prevents smnrp to start in case a password is empty. @dameyerdave what do you think?